### PR TITLE
Migrate Python CI resource classes to matrix names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       COLUMNS: '160'
       PATH: /root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       CONTEXT_NAME: << pipeline.parameters.context_name >>
-      DEPS_INSTALL_TIMEOUT: 10m
+      DEPS_INSTALL_TIMEOUT: '10m'
       COVER_PACKAGES: compmake,compmake_plugins,compmake_tests,compmake_utils
       TEST_PACKAGES: compmake_tests
       Z_SERVICE_FS: zuper_fs_local.use_local_fs
@@ -27,6 +27,9 @@ jobs:
       Z_SERVICE_PROC: zuper_proc_local.proc
     docker:
     - image: docker.io/${DOCKER_TARGET_ORG}/${DOCKER_REPO_PREFIX}zuper-ci-3.13:${Z_DISTRO}
+      auth:
+        username: $DOCKER_IO_READONLY_USERNAME
+        password: $DOCKER_IO_READONLY_TOKEN
     working_directory: ~/repo
     steps:
     - checkout
@@ -46,25 +49,7 @@ jobs:
           echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
     - run:
         name: Build statistics
-        command: |
-          set -x
-          mkdir -p build-stats
-          # image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`
-          # registry_to_login=`echo ${image_name} | cut -d'/' -f1`
-          # regctl registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" "${registry_to_login}"
-
-          # regctl manifest get --format raw-body "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json
-          # regctl image digest "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt
-          # echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt
-
-          mkdir -p build-stats/envs
-          mkdir -p build-stats/jobs/${CIRCLE_JOB}
-          mkdir -p build-stats/jobs/${CIRCLE_JOB}/envs
-          echo -n "${Z_REQS_SHA:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA
-          echo -n "${IMAGE_VCS_SHA:-not-present}"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA
-          echo -n "${IMAGE_NAME:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME
-          echo -n "${CONTEXT_NAME:-not-present}"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME
-          echo -n "${PYTHONOPTIMIZE:-not-present}" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE
+        command: "set -x \nmkdir -p build-stats\n# image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`\n# registry_to_login=`echo ${image_name} | cut -d'/' -f1`\n# regctl registry login -u \"${DOCKER_USERNAME}\" -p \"${DOCKER_PASSWORD}\" \"${registry_to_login}\"\n\nlogical_job=${ZUPER_CIRCLE_LOGICAL_JOB:-${CIRCLE_JOB}}\n# regctl manifest get --format raw-body \"${image_name}\" > build-stats/jobs/${logical_job}/image-manifest.json\n# regctl image digest \"${image_name}\" > build-stats/jobs/${logical_job}/image-digest.txt\n# echo ${image_name} > build-stats/jobs/${logical_job}/image-name.txt\n\nmkdir -p build-stats/envs\nmkdir -p build-stats/jobs/${logical_job}\nmkdir -p build-stats/jobs/${logical_job}/envs\necho -n \"${Z_REQS_SHA:-not-present}\"     > build-stats/jobs/${logical_job}/envs/Z_REQS_SHA\necho -n \"${IMAGE_VCS_SHA:-not-present}\"  > build-stats/jobs/${logical_job}/envs/IMAGE_VCS_SHA\necho -n \"${IMAGE_NAME:-not-present}\"     > build-stats/jobs/${logical_job}/envs/IMAGE_NAME\necho -n \"${CONTEXT_NAME:-not-present}\"   > build-stats/jobs/${logical_job}/envs/CONTEXT_NAME\necho -n \"${PYTHONOPTIMIZE:-not-present}\" > build-stats/jobs/${logical_job}/envs/PYTHONOPTIMIZE\n"
     - store_artifacts:
         path: build-stats
         destination: build-stats
@@ -73,7 +58,7 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          shyaml get-values install_requires < project.pp1.yaml > .requirements.txt
+          printf '%s\n' 'PyYAML' 'Pympler' 'SystemCmd-z7' 'coverage' 'dill' 'lxml' 'networkx' 'numpy' 'psutil' 'pyreadline' 'setproctitle' 'zuper-commons-z7' 'zuper-typing-z7' 'zuper-utils-asyncio-z7' 'zuper-utils-timing-z7' 'zuper-zapp-interfaces-z7' 'zuper-zapp-z7' > .requirements.txt
           saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements.txt
           rm .requirements.txt
     - run:
@@ -81,7 +66,7 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          shyaml get-values tests_require < project.pp1.yaml > .requirements_tests.txt
+          : > .requirements_tests.txt
           saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-testing-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements_tests.txt
           rm .requirements_tests.txt
     - run:
@@ -89,7 +74,7 @@ jobs:
         command: |-
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          python3 -m pip install zuper-notes-z7 zuper-loghandle-z7 zuper-fs-local-z7 zuper-proc-local-z7
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/add-more-packages --heartbeat 30s --stats-interval 5s -- python3 -m pip install zuper-notes-z7 zuper-loghandle-z7 zuper-fs-local-z7 zuper-proc-local-z7
     - run:
         name: Python stats
         command: |
@@ -143,23 +128,23 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
+          test_list=.circleci/compmake_tests.tests
+          if [ ! -f "$test_list" ]; then
+            echo "$test_list is absent; no tests selected"
+            exit 0
+          fi
           set -euxo pipefail
           TEST_MODULES=$(split-tests <.circleci/compmake_tests.tests)
           echo "TEST_MODULES=[$TEST_MODULES]"
           if [ -z "$TEST_MODULES" ]; then
-            echo "\$TEST_MODULES is empty"
+            echo "$TEST_MODULES is empty"
             exit 0
           else
-            echo "\$TEST_MODULES is NOT empty"
+            echo "$TEST_MODULES is NOT empty"
           fi
           mkdir -p out/test-results
-          xunit_output=$PWD/out/test-results/nose2-${CIRCLE_NODE_INDEX}-compmake_tests-xunit.xml
-          timeout 30m nose2 --with-coverage \
-              --plugin nose2.plugins.junitxml \
-              --junit-xml \
-              --junit-xml-path ${xunit_output} \
-              $TEST_MODULES
-          # TODO: cover packages
+          xunit_output=$PWD/out/test-results/nose-${CIRCLE_NODE_INDEX}-compmake_tests-xunit.xml
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/test-compmake_tests --heartbeat 30s --stats-interval 5s -- timeout 30m nose2 --with-coverage --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path ${xunit_output} $TEST_MODULES
     - run:
         name: post-circle-tests
         when: always
@@ -195,7 +180,7 @@ jobs:
           timeout 1m ./codecov || true
     resource_class: andreacensi/r2
 
-# sigil a940f9efa4fa97bc7dc0a1e20d88b713
-# Agents: DO NOT MODIFY THIS FILE DIRECTLY - it is autogenerated using zuper-cli template from project.pp1.yaml
-# It is very likely you can obtain what you want by modifying the config.
-# In any case you need the user's explicit permissions.
+# sigil 4a0bf05a280472012cee21a419f9899e
+# template-meta agent-advice=Do not modify this file directly; it is autogenerated by zuper-templating from project.pp1.yaml. Modify project.pp1.yaml instead; direct changes require explicit user permission.
+# template-meta template-version=2.1
+# template-meta zuper-templating-version=8.36.2901010000

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,46 @@
-exclude: .pre-commit-config.yaml|(.*autogen.*py)
-files: (^src/.*py)|(.*yaml)
 repos:
-- hooks:
-  - {id: check-added-large-files}
-  - {id: check-case-conflict}
-  - {id: check-executables-have-shebangs}
-  - {id: check-merge-conflict}
-  - {id: check-symlinks}
-  repo: https://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
-- hooks:
-  - args: [--mapping, '2', --sequence, '2', --offset, '0', --width, '150', --preserve-quotes]
-    id: yamlfmt
-  repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.2.3
-- hooks:
-  - {id: sort-all}
-  repo: https://github.com/aio-libs/sort-all
+  hooks:
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-symlinks
+- repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+  rev: '0.2.3'
+  hooks:
+  - id: yamlfmt
+    args:
+    - '--mapping'
+    - '2'
+    - '--sequence'
+    - '2'
+    - '--offset'
+    - '0'
+    - '--width'
+    - '150'
+    - '--preserve-quotes'
+- repo: https://github.com/aio-libs/sort-all
   rev: v1.3.0
-- hooks:
-  - args: [--line-length=130]
-    id: ruff-format
-    name: ruff-format
-  - args: [--fix, --select=I, --line-length=130]
-    id: ruff
-    name: ruff-lint
-  repo: https://github.com/astral-sh/ruff-pre-commit
+  hooks:
+  - id: sort-all
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.10
+  hooks:
+  - id: ruff-format
+    name: ruff-format
+    args:
+    - '--line-length=130'
+  - id: ruff
+    name: ruff-lint
+    args:
+    - '--fix'
+    - '--select=I'
+    - '--line-length=130'
+files: (^src/.*py)|(.*yaml)
+exclude: '.pre-commit-config.yaml|(.*autogen.*py)'
 
-# sigil 02fbf2b91c16b02e86d63a5ea12cd92b
+# sigil f6872e085fe9bd19b2afebd99dff214f
+# template-meta template-version=2.1
+# template-meta zuper-templating-version=8.36.2901010000

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ prune src/*_tests*
 prune out
 prune assets
 
+
 #@ add local below
 
 include *.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,25 +3,8 @@ name = "compmake-z7"
 version = "7.2"
 readme = ""
 description = ""
-authors = [{name = "Andrea Censi", email = "AndreaCensi@users.noreply.github.com"}]
-dependencies = [
-    "PyYAML",
-    "Pympler",
-    "SystemCmd-z7",
-    "coverage",
-    "dill",
-    "lxml",
-    "networkx",
-    "numpy",
-    "psutil",
-    "pyreadline",
-    "setproctitle",
-    "zuper-commons-z7",
-    "zuper-typing-z7",
-    "zuper-utils-asyncio-z7",
-    "zuper-utils-timing-z7",
-    "zuper-zapp-interfaces-z7",
-    "zuper-zapp-z7",]
+authors = [{ name = "Andrea Censi", email = "AndreaCensi@users.noreply.github.com" }]
+dependencies = ["PyYAML", "Pympler", "SystemCmd-z7", "coverage", "dill", "lxml", "networkx", "numpy", "psutil", "pyreadline", "setproctitle", "zuper-commons-z7", "zuper-typing-z7", "zuper-utils-asyncio-z7", "zuper-utils-timing-z7", "zuper-zapp-interfaces-z7", "zuper-zapp-z7"]
 
 [project.scripts]
 compmake = "compmake:main"
@@ -30,8 +13,7 @@ compmake-run = "compmake:compmake_run_main"
 compmake-tracemalloc = "compmake:compmake_tracemalloc_main"
 
 [project.optional-dependencies]
-test = [
-    ]
+test = []
 
 [tool.poetry]
 name = "compmake-z7"
@@ -39,14 +21,14 @@ version = "7.2"
 description = ""
 authors = ["Andrea Censi <AndreaCensi@users.noreply.github.com>"]
 packages = [
-    {from = "src", include = "compmake"},
-    {from = "src", include = "compmake_plugins"},
-    {from = "src", include = "compmake_plugins/backend_local"},
-    {from = "src", include = "compmake_plugins/backend_pmake"},
-    {from = "src", include = "compmake_plugins/backend_ssh_cluster"},
-    {from = "src", include = "compmake_plugins/execution_stats"},
-    {from = "src", include = "compmake_utils"},
-    ]
+    { from = "src", include = "compmake" },
+    { from = "src", include = "compmake_plugins" },
+    { from = "src", include = "compmake_plugins/backend_local" },
+    { from = "src", include = "compmake_plugins/backend_pmake" },
+    { from = "src", include = "compmake_plugins/backend_ssh_cluster" },
+    { from = "src", include = "compmake_plugins/execution_stats" },
+    { from = "src", include = "compmake_utils" },
+]
 
 [tool.poetry.dependencies]
 PyYAML = "*"
@@ -77,6 +59,5 @@ compmake-run = "compmake:compmake_run_main"
 compmake-tracemalloc = "compmake:compmake_tracemalloc_main"
 
 [build-system]
-requires = [
-    "poetry-core>=1.0.0",]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Updates this Python repository to the matrix-named CircleCI resource classes and regenerates the template-managed files with zuper-templating 8.36.2901010000.

Legacy capacity mappings preserve the existing runner sizes: r1 -> c1m6, r2 -> c2m12, r4 -> c4m24, and r8 -> c8m48.

The main checkout was not modified.

Preserves the existing unmanaged Makefile; only managed generated files were regenerated.